### PR TITLE
error  'reset' is missing in props validation  react/prop-types

### DIFF
--- a/src/components/matrix/index.js
+++ b/src/components/matrix/index.js
@@ -168,4 +168,5 @@ export default class Matrix extends React.Component {
 Matrix.propTypes = {
   matrix: React.PropTypes.object.isRequired,
   cur: React.PropTypes.object,
+  reset: React.PropTypes.object
 };


### PR DESCRIPTION
chunk    {0} app.js, 0.e56c7632abd35c5875ac.hot-update.js, css.css, app.js.map, 0.e56c7632abd35c5875ac.hot-update.js.map, css.css.map (main) 1.27 MB [rendered]
  [326] ./src/components/matrix/index.js 7.49 kB {0} [built] [1 error]
     + 360 hidden modules

ERROR in ./src/components/matrix/index.js

/home/leonard/0-computaciones/espacio/test/react-tetris-master/src/components/matrix/index.js
  23:29  error  'reset' is missing in props validation  react/prop-types

✖ 1 problem (1 error, 0 warnings)

webpack: Failed to compile.